### PR TITLE
Refactor: Optimize for PHP 8.4 and improve type hinting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.3",
     "ext-json": "*",
     "ext-pdo": "*",
     "gcworld/common":"^2.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "031461aa394b83104d732ba3f98297b3",
+    "content-hash": "be737c19f33a4e580927e19a9c2219f0",
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.12.1",
+            "version": "0.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
+                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
-                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
+                "url": "https://api.github.com/repos/brick/math/zipball/866551da34e9a618e64a819ee1e01c20d8a588ba",
+                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
                 "phpunit/phpunit": "^10.1",
-                "vimeo/psalm": "5.16.0"
+                "vimeo/psalm": "6.8.8"
             },
             "type": "library",
             "autoload": {
@@ -56,7 +56,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.12.1"
+                "source": "https://github.com/brick/math/tree/0.12.3"
             },
             "funding": [
                 {
@@ -64,20 +64,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-29T23:19:16+00:00"
+            "time": "2025-02-28T13:11:00+00:00"
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.5",
+            "version": "1.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "08c50d5ec4c6ced7d0271d2862dec8c1033283e6"
+                "reference": "f65c239c970e7f072f067ab78646e9f0b2935175"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/08c50d5ec4c6ced7d0271d2862dec8c1033283e6",
-                "reference": "08c50d5ec4c6ced7d0271d2862dec8c1033283e6",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/f65c239c970e7f072f067ab78646e9f0b2935175",
+                "reference": "f65c239c970e7f072f067ab78646e9f0b2935175",
                 "shasum": ""
             },
             "require": {
@@ -124,7 +124,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.5"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.6"
             },
             "funding": [
                 {
@@ -140,20 +140,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-08T16:17:16+00:00"
+            "time": "2025-03-06T14:30:56+00:00"
         },
         {
             "name": "composer/class-map-generator",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "ffe442c5974c44a9343e37a0abcb1cc37319f5b9"
+                "reference": "134b705ddb0025d397d8318a75825fe3c9d1da34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/ffe442c5974c44a9343e37a0abcb1cc37319f5b9",
-                "reference": "ffe442c5974c44a9343e37a0abcb1cc37319f5b9",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/134b705ddb0025d397d8318a75825fe3c9d1da34",
+                "reference": "134b705ddb0025d397d8318a75825fe3c9d1da34",
                 "shasum": ""
             },
             "require": {
@@ -197,7 +197,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.6.0"
+                "source": "https://github.com/composer/class-map-generator/tree/1.6.1"
             },
             "funding": [
                 {
@@ -213,20 +213,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-05T10:05:34+00:00"
+            "time": "2025-03-24T13:50:44+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "2.8.5",
+            "version": "2.8.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "ae208dc1e182bd45d99fcecb956501da212454a1"
+                "reference": "b4e6bff2db7ce756ddb77ecee958a0f41f42bd9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/ae208dc1e182bd45d99fcecb956501da212454a1",
-                "reference": "ae208dc1e182bd45d99fcecb956501da212454a1",
+                "url": "https://api.github.com/repos/composer/composer/zipball/b4e6bff2db7ce756ddb77ecee958a0f41f42bd9d",
+                "reference": "b4e6bff2db7ce756ddb77ecee958a0f41f42bd9d",
                 "shasum": ""
             },
             "require": {
@@ -237,7 +237,7 @@
                 "composer/semver": "^3.3",
                 "composer/spdx-licenses": "^1.5.7",
                 "composer/xdebug-handler": "^2.0.2 || ^3.0.3",
-                "justinrainbow/json-schema": "^5.3",
+                "justinrainbow/json-schema": "^6.3.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "react/promise": "^2.11 || ^3.2",
@@ -311,7 +311,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.8.5"
+                "source": "https://github.com/composer/composer/tree/2.8.9"
             },
             "funding": [
                 {
@@ -327,7 +327,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-21T14:23:40+00:00"
+            "time": "2025-05-13T12:01:37+00:00"
         },
         {
             "name": "composer/installers",
@@ -706,24 +706,24 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.5.8",
+            "version": "1.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a"
+                "reference": "edf364cefe8c43501e21e88110aac10b284c3c9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
-                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/edf364cefe8c43501e21e88110aac10b284c3c9f",
+                "reference": "edf364cefe8c43501e21e88110aac10b284c3c9f",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.55",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
             },
             "type": "library",
             "extra": {
@@ -766,7 +766,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/spdx-licenses/issues",
-                "source": "https://github.com/composer/spdx-licenses/tree/1.5.8"
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.9"
             },
             "funding": [
                 {
@@ -782,7 +782,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-20T07:44:33+00:00"
+            "time": "2025-05-12T21:07:07+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -852,16 +852,16 @@
         },
         {
             "name": "gcworld/common",
-            "version": "2.7.5",
+            "version": "2.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KongHack/Common.git",
-                "reference": "0cf487f04de6963c11ed858396fcdbf1333d2ed3"
+                "reference": "1d6fe0ef9cefa80b52d9d39435839a000156b819"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KongHack/Common/zipball/0cf487f04de6963c11ed858396fcdbf1333d2ed3",
-                "reference": "0cf487f04de6963c11ed858396fcdbf1333d2ed3",
+                "url": "https://api.github.com/repos/KongHack/Common/zipball/1d6fe0ef9cefa80b52d9d39435839a000156b819",
+                "reference": "1d6fe0ef9cefa80b52d9d39435839a000156b819",
                 "shasum": ""
             },
             "require": {
@@ -895,35 +895,35 @@
             "description": "GCWorld Industries Common",
             "support": {
                 "issues": "https://github.com/KongHack/Common/issues",
-                "source": "https://github.com/KongHack/Common/tree/2.7.5"
+                "source": "https://github.com/KongHack/Common/tree/2.7.7"
             },
-            "time": "2025-02-11T15:05:33+00:00"
+            "time": "2025-02-24T21:40:09+00:00"
         },
         {
             "name": "gcworld/database",
-            "version": "2.7.0",
+            "version": "2.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KongHack/Database.git",
-                "reference": "2a556b46c17b3a38978741995fed479514eb2a8f"
+                "reference": "e2b7c64b9af972cc174f2dbb692ca797232b487b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KongHack/Database/zipball/2a556b46c17b3a38978741995fed479514eb2a8f",
-                "reference": "2a556b46c17b3a38978741995fed479514eb2a8f",
+                "url": "https://api.github.com/repos/KongHack/Database/zipball/e2b7c64b9af972cc174f2dbb692ca797232b487b",
+                "reference": "e2b7c64b9af972cc174f2dbb692ca797232b487b",
                 "shasum": ""
             },
             "require": {
-                "composer/composer": "^2.8",
-                "composer/installers": ">=2.3",
+                "composer/composer": "^2.7",
+                "composer/installers": ">=2.2",
                 "ext-pdo": "*",
-                "gcworld/interfaces": ">=4.3",
-                "php": ">=8.4"
+                "gcworld/interfaces": ">=4.1.0",
+                "php": ">=8.0"
             },
             "require-dev": {
                 "gcworld/code_sniffer_contrib": "^1.0",
-                "phpmd/phpmd": "^2.15",
-                "phpstan/phpstan": "^1.12"
+                "phpmd/phpmd": "^2.6",
+                "phpstan/phpstan": "^1.4"
             },
             "type": "library",
             "autoload": {
@@ -944,9 +944,9 @@
             "description": "GCWorld Industries Database",
             "support": {
                 "issues": "https://github.com/KongHack/Database/issues",
-                "source": "https://github.com/KongHack/Database/tree/2.7.0"
+                "source": "https://github.com/KongHack/Database/tree/2.6.7"
             },
-            "time": "2025-02-17T22:18:18+00:00"
+            "time": "2025-02-16T04:33:28+00:00"
         },
         {
             "name": "gcworld/errorhandlers",
@@ -1080,30 +1080,40 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.3.0",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8"
+                "reference": "35d262c94959571e8736db1e5c9bc36ab94ae900"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
-                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/35d262c94959571e8736db1e5c9bc36ab94ae900",
+                "reference": "35d262c94959571e8736db1e5c9bc36ab94ae900",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "ext-json": "*",
+                "marc-mabe/php-enum": "^4.0",
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "friendsofphp/php-cs-fixer": "3.3.0",
                 "json-schema/json-schema-test-suite": "1.2.0",
-                "phpunit/phpunit": "^4.8.35"
+                "marc-mabe/php-enum-phpstan": "^2.0",
+                "phpspec/prophecy": "^1.19",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^8.5"
             },
             "bin": [
                 "bin/validate-json"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "JsonSchema\\": "src/JsonSchema/"
@@ -1132,16 +1142,16 @@
                 }
             ],
             "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
+            "homepage": "https://github.com/jsonrainbow/json-schema",
             "keywords": [
                 "json",
                 "schema"
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/5.3.0"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.4.1"
             },
-            "time": "2024-07-06T21:00:26+00:00"
+            "time": "2025-04-04T13:08:07+00:00"
         },
         {
             "name": "kint-php/kint",
@@ -1207,17 +1217,90 @@
             "time": "2025-01-01T23:10:26+00:00"
         },
         {
-            "name": "monolog/monolog",
-            "version": "3.8.1",
+            "name": "marc-mabe/php-enum",
+            "version": "v4.7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "aef6ee73a77a66e404dd6540934a9ef1b3c855b4"
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "7159809e5cfa041dca28e61f7f7ae58063aae8ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/aef6ee73a77a66e404dd6540934a9ef1b3c855b4",
-                "reference": "aef6ee73a77a66e404dd6540934a9ef1b3c855b4",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/7159809e5cfa041dca28e61f7f7ae58063aae8ed",
+                "reference": "7159809e5cfa041dca28e61f7f7ae58063aae8ed",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": "^7.1 | ^8.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.16.10 || ^1.0.4",
+                "phpstan/phpstan": "^1.3.1",
+                "phpunit/phpunit": "^7.5.20 | ^8.5.22 | ^9.5.11",
+                "vimeo/psalm": "^4.17.0 | ^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.2-dev",
+                    "dev-master": "4.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "https://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enumerator",
+                "enummap",
+                "enumset",
+                "map",
+                "set",
+                "type",
+                "type-hint",
+                "typehint"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum/issues",
+                "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.1"
+            },
+            "time": "2024-11-28T04:54:44+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "3.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
                 "shasum": ""
             },
             "require": {
@@ -1295,7 +1378,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.8.1"
+                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
             },
             "funding": [
                 {
@@ -1307,20 +1390,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-05T17:15:07+00:00"
+            "time": "2025-03-24T10:02:05+00:00"
         },
         {
             "name": "nette/php-generator",
-            "version": "v4.1.7",
+            "version": "v4.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/php-generator.git",
-                "reference": "d201c9bc217e0969d1b678d286be49302972fb56"
+                "reference": "42806049a7774a2bd316c958f5dcf01c6b5c56fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/d201c9bc217e0969d1b678d286be49302972fb56",
-                "reference": "d201c9bc217e0969d1b678d286be49302972fb56",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/42806049a7774a2bd316c958f5dcf01c6b5c56fa",
+                "reference": "42806049a7774a2bd316c958f5dcf01c6b5c56fa",
                 "shasum": ""
             },
             "require": {
@@ -1374,22 +1457,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/php-generator/issues",
-                "source": "https://github.com/nette/php-generator/tree/v4.1.7"
+                "source": "https://github.com/nette/php-generator/tree/v4.1.8"
             },
-            "time": "2024-11-29T01:41:18+00:00"
+            "time": "2025-03-31T00:29:29+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.5",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96"
+                "reference": "ce708655043c7050eb050df361c5e313cf708309"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
-                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
+                "url": "https://api.github.com/repos/nette/utils/zipball/ce708655043c7050eb050df361c5e313cf708309",
+                "reference": "ce708655043c7050eb050df361c5e313cf708309",
                 "shasum": ""
             },
             "require": {
@@ -1460,9 +1543,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.5"
+                "source": "https://github.com/nette/utils/tree/v4.0.6"
             },
-            "time": "2024-08-07T15:39:19+00:00"
+            "time": "2025-03-30T21:06:30+00:00"
         },
         {
             "name": "psr/container",
@@ -1569,16 +1652,16 @@
         },
         {
             "name": "ramsey/collection",
-            "version": "2.0.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/collection.git",
-                "reference": "a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5"
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/collection/zipball/a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5",
-                "reference": "a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2",
                 "shasum": ""
             },
             "require": {
@@ -1586,25 +1669,22 @@
             },
             "require-dev": {
                 "captainhook/plugin-composer": "^5.3",
-                "ergebnis/composer-normalize": "^2.28.3",
-                "fakerphp/faker": "^1.21",
+                "ergebnis/composer-normalize": "^2.45",
+                "fakerphp/faker": "^1.24",
                 "hamcrest/hamcrest-php": "^2.0",
-                "jangregor/phpstan-prophecy": "^1.0",
-                "mockery/mockery": "^1.5",
+                "jangregor/phpstan-prophecy": "^2.1",
+                "mockery/mockery": "^1.6",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3",
-                "phpcsstandards/phpcsutils": "^1.0.0-rc1",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpstan/extension-installer": "^1.2",
-                "phpstan/phpstan": "^1.9",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5",
-                "psalm/plugin-mockery": "^1.1",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "ramsey/coding-standard": "^2.0.3",
-                "ramsey/conventional-commits": "^1.3",
-                "vimeo/psalm": "^5.4"
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpspec/prophecy-phpunit": "^2.3",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "ramsey/coding-standard": "^2.3",
+                "ramsey/conventional-commits": "^1.6",
+                "roave/security-advisories": "dev-latest"
             },
             "type": "library",
             "extra": {
@@ -1642,19 +1722,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/collection/issues",
-                "source": "https://github.com/ramsey/collection/tree/2.0.0"
+                "source": "https://github.com/ramsey/collection/tree/2.1.1"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/ramsey",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/ramsey/collection",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-31T21:50:55+00:00"
+            "time": "2025-03-22T05:38:12+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -1996,16 +2066,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.2.1",
+            "version": "v7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3"
+                "reference": "0e2e3f38c192e93e622e41ec37f4ca70cfedf218"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
-                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0e2e3f38c192e93e622e41ec37f4ca70cfedf218",
+                "reference": "0e2e3f38c192e93e622e41ec37f4ca70cfedf218",
                 "shasum": ""
             },
             "require": {
@@ -2069,7 +2139,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.2.1"
+                "source": "https://github.com/symfony/console/tree/v7.2.6"
             },
             "funding": [
                 {
@@ -2085,7 +2155,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-11T03:49:26+00:00"
+            "time": "2025-04-07T19:09:28+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2286,7 +2356,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -2345,7 +2415,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2365,7 +2435,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -2423,7 +2493,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2443,7 +2513,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -2504,7 +2574,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2524,19 +2594,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
+                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -2584,7 +2655,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2600,11 +2671,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -2660,7 +2731,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2680,16 +2751,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
@@ -2740,7 +2811,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2756,11 +2827,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -2816,7 +2887,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2836,16 +2907,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.2.0",
+            "version": "v7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d34b22ba9390ec19d2dd966c40aa9e8462f27a7e"
+                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d34b22ba9390ec19d2dd966c40aa9e8462f27a7e",
-                "reference": "d34b22ba9390ec19d2dd966c40aa9e8462f27a7e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/87b7c93e57df9d8e39a093d32587702380ff045d",
+                "reference": "87b7c93e57df9d8e39a093d32587702380ff045d",
                 "shasum": ""
             },
             "require": {
@@ -2877,7 +2948,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.2.0"
+                "source": "https://github.com/symfony/process/tree/v7.2.5"
             },
             "funding": [
                 {
@@ -2893,7 +2964,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-06T14:24:19+00:00"
+            "time": "2025-03-13T12:21:46+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -2980,16 +3051,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.2.0",
+            "version": "v7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82"
+                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/446e0d146f991dde3e73f45f2c97a9faad773c82",
-                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "url": "https://api.github.com/repos/symfony/string/zipball/a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
+                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
                 "shasum": ""
             },
             "require": {
@@ -3047,7 +3118,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.2.0"
+                "source": "https://github.com/symfony/string/tree/v7.2.6"
             },
             "funding": [
                 {
@@ -3063,20 +3134,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T13:31:26+00:00"
+            "time": "2025-04-20T20:18:16+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.18",
+            "version": "v6.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "bf598c9d9bb4a22f495a4e26e4c4fce2f8ecefc5"
+                "reference": "f01987f45676778b474468aa266fe2eda1f2bc7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/bf598c9d9bb4a22f495a4e26e4c4fce2f8ecefc5",
-                "reference": "bf598c9d9bb4a22f495a4e26e4c4fce2f8ecefc5",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f01987f45676778b474468aa266fe2eda1f2bc7e",
+                "reference": "f01987f45676778b474468aa266fe2eda1f2bc7e",
                 "shasum": ""
             },
             "require": {
@@ -3119,7 +3190,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.18"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.21"
             },
             "funding": [
                 {
@@ -3135,20 +3206,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-07T09:44:41+00:00"
+            "time": "2025-04-04T09:48:44+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v3.20.0",
+            "version": "v3.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3468920399451a384bef53cf7996965f7cd40183"
+                "reference": "285123877d4dd97dd7c11842ac5fb7e86e60d81d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3468920399451a384bef53cf7996965f7cd40183",
-                "reference": "3468920399451a384bef53cf7996965f7cd40183",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/285123877d4dd97dd7c11842ac5fb7e86e60d81d",
+                "reference": "285123877d4dd97dd7c11842ac5fb7e86e60d81d",
                 "shasum": ""
             },
             "require": {
@@ -3202,7 +3273,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.20.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.21.1"
             },
             "funding": [
                 {
@@ -3214,7 +3285,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-13T08:34:43+00:00"
+            "time": "2025-05-03T07:21:55+00:00"
         }
     ],
     "packages-dev": [
@@ -3392,16 +3463,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.69.1",
+            "version": "v3.75.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "13b0c0eede38c11cd674b080f2b485d0f14ffa9f"
+                "reference": "399a128ff2fdaf4281e4e79b755693286cdf325c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/13b0c0eede38c11cd674b080f2b485d0f14ffa9f",
-                "reference": "13b0c0eede38c11cd674b080f2b485d0f14ffa9f",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/399a128ff2fdaf4281e4e79b755693286cdf325c",
+                "reference": "399a128ff2fdaf4281e4e79b755693286cdf325c",
                 "shasum": ""
             },
             "require": {
@@ -3409,6 +3480,7 @@
                 "composer/semver": "^3.4",
                 "composer/xdebug-handler": "^3.0.3",
                 "ext-filter": "*",
+                "ext-hash": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "fidry/cpu-core-counter": "^1.2",
@@ -3431,18 +3503,18 @@
                 "symfony/stopwatch": "^5.4 || ^6.4 || ^7.0"
             },
             "require-dev": {
-                "facile-it/paraunit": "^1.3.1 || ^2.5",
-                "infection/infection": "^0.29.10",
-                "justinrainbow/json-schema": "^5.3 || ^6.0",
+                "facile-it/paraunit": "^1.3.1 || ^2.6",
+                "infection/infection": "^0.29.14",
+                "justinrainbow/json-schema": "^5.3 || ^6.2",
                 "keradus/cli-executor": "^2.1",
                 "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.7",
                 "php-cs-fixer/accessible-object": "^1.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.6",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.6",
-                "phpunit/phpunit": "^9.6.22 || ^10.5.45 || ^11.5.7",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.18 || ^7.2.0",
-                "symfony/yaml": "^5.4.45 || ^6.4.18 || ^7.2.0"
+                "phpunit/phpunit": "^9.6.22 || ^10.5.45 || ^11.5.12",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.18 || ^7.2.3",
+                "symfony/yaml": "^5.4.45 || ^6.4.18 || ^7.2.3"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -3483,7 +3555,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.69.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.75.0"
             },
             "funding": [
                 {
@@ -3491,20 +3563,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-18T23:57:43+00:00"
+            "time": "2025-03-31T18:40:42+00:00"
         },
         {
             "name": "gcworld/code_sniffer_contrib",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GameCharmer/CodeSnifferContrib.git",
-                "reference": "3f4c842565c3eb7bc3e20c23ac1927ba1c82fd5d"
+                "reference": "c32e8efc8856da144a6a9de6fabca6fce2a610f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GameCharmer/CodeSnifferContrib/zipball/3f4c842565c3eb7bc3e20c23ac1927ba1c82fd5d",
-                "reference": "3f4c842565c3eb7bc3e20c23ac1927ba1c82fd5d",
+                "url": "https://api.github.com/repos/GameCharmer/CodeSnifferContrib/zipball/c32e8efc8856da144a6a9de6fabca6fce2a610f7",
+                "reference": "c32e8efc8856da144a6a9de6fabca6fce2a610f7",
                 "shasum": ""
             },
             "require": {
@@ -3536,9 +3608,9 @@
             ],
             "support": {
                 "issues": "https://github.com/GameCharmer/CodeSnifferContrib/issues",
-                "source": "https://github.com/GameCharmer/CodeSnifferContrib/tree/2.1.3"
+                "source": "https://github.com/GameCharmer/CodeSnifferContrib/tree/2.1.4"
             },
-            "time": "2024-12-11T14:28:07+00:00"
+            "time": "2025-04-07T12:15:47+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -3688,16 +3760,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.19",
+            "version": "1.12.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c42ba9bab7a940ed00092ecb1c77bad98896d789"
+                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c42ba9bab7a940ed00092ecb1c77bad98896d789",
-                "reference": "c42ba9bab7a940ed00092ecb1c77bad98896d789",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3a6e423c076ab39dfedc307e2ac627ef579db162",
+                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162",
                 "shasum": ""
             },
             "require": {
@@ -3742,7 +3814,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-19T15:42:21+00:00"
+            "time": "2025-05-21T20:51:45+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -4316,16 +4388,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.3",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10"
+                "reference": "65ff2489553b83b4597e89c3b8b721487011d186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/65ff2489553b83b4597e89c3b8b721487011d186",
+                "reference": "65ff2489553b83b4597e89c3b8b721487011d186",
                 "shasum": ""
             },
             "require": {
@@ -4392,24 +4464,24 @@
                     "type": "open_collective"
                 },
                 {
-                    "url": "https://thanks.dev/phpcsstandards",
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-01-23T17:04:15+00:00"
+            "time": "2025-05-11T03:36:00+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v7.2.3",
+            "version": "v7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "7716594aaae91d9141be080240172a92ecca4d44"
+                "reference": "e0b050b83ba999aa77a3736cb6d5b206d65b9d0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/7716594aaae91d9141be080240172a92ecca4d44",
-                "reference": "7716594aaae91d9141be080240172a92ecca4d44",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e0b050b83ba999aa77a3736cb6d5b206d65b9d0d",
+                "reference": "e0b050b83ba999aa77a3736cb6d5b206d65b9d0d",
                 "shasum": ""
             },
             "require": {
@@ -4455,7 +4527,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.2.3"
+                "source": "https://github.com/symfony/config/tree/v7.2.6"
             },
             "funding": [
                 {
@@ -4471,20 +4543,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-22T12:07:01+00:00"
+            "time": "2025-04-03T21:14:15+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.2.3",
+            "version": "v7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "1d321c4bc3fe926fd4c38999a4c9af4f5d61ddfc"
+                "reference": "2ca85496cde37f825bd14f7e3548e2793ca90712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/1d321c4bc3fe926fd4c38999a4c9af4f5d61ddfc",
-                "reference": "1d321c4bc3fe926fd4c38999a4c9af4f5d61ddfc",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/2ca85496cde37f825bd14f7e3548e2793ca90712",
+                "reference": "2ca85496cde37f825bd14f7e3548e2793ca90712",
                 "shasum": ""
             },
             "require": {
@@ -4492,7 +4564,7 @@
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^3.5",
-                "symfony/var-exporter": "^6.4|^7.0"
+                "symfony/var-exporter": "^6.4.20|^7.2.5"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
@@ -4535,7 +4607,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.3"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.6"
             },
             "funding": [
                 {
@@ -4551,7 +4623,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-17T10:56:55+00:00"
+            "time": "2025-04-27T13:37:55+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -4778,16 +4850,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v7.2.2",
+            "version": "v7.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "e46690d5b9d7164a6d061cab1e8d46141b9f49df"
+                "reference": "5a49289e2b308214c8b9c2fda4ea454d8b8ad7cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/e46690d5b9d7164a6d061cab1e8d46141b9f49df",
-                "reference": "e46690d5b9d7164a6d061cab1e8d46141b9f49df",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5a49289e2b308214c8b9c2fda4ea454d8b8ad7cd",
+                "reference": "5a49289e2b308214c8b9c2fda4ea454d8b8ad7cd",
                 "shasum": ""
             },
             "require": {
@@ -4820,7 +4892,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v7.2.2"
+                "source": "https://github.com/symfony/stopwatch/tree/v7.2.4"
             },
             "funding": [
                 {
@@ -4836,20 +4908,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-18T14:28:33+00:00"
+            "time": "2025-02-24T10:49:57+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.2.0",
+            "version": "v7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "1a6a89f95a46af0f142874c9d650a6358d13070d"
+                "reference": "422b8de94c738830a1e071f59ad14d67417d7007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/1a6a89f95a46af0f142874c9d650a6358d13070d",
-                "reference": "1a6a89f95a46af0f142874c9d650a6358d13070d",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/422b8de94c738830a1e071f59ad14d67417d7007",
+                "reference": "422b8de94c738830a1e071f59ad14d67417d7007",
                 "shasum": ""
             },
             "require": {
@@ -4896,7 +4968,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.2.0"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.2.6"
             },
             "funding": [
                 {
@@ -4912,7 +4984,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-18T07:58:17+00:00"
+            "time": "2025-05-02T08:36:00+00:00"
         }
     ],
     "aliases": [],
@@ -4921,7 +4993,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1",
+        "php": ">=8.3",
         "ext-json": "*",
         "ext-pdo": "*"
     },

--- a/src/Abstracts/DirectSingle.php
+++ b/src/Abstracts/DirectSingle.php
@@ -23,19 +23,17 @@ abstract class DirectSingle implements DirectSingleInterface
     /**
      * Here for reference, will be created in child objects automatically.
      *
-     * @var array
+     * @var array<string, mixed>
      */
-    public static $dbInfo = [];
+    public static array $dbInfo = [];
     /**
      * @var \GCWorld\Common\Common|CommonInterface
      */
-    protected $_common;
+    protected readonly CommonInterface $_common;
     /**
      * Set this in the event your class needs a non-standard DB.
-     *
-     * @var string|null
      */
-    protected $_dbName;
+    protected ?string $_dbName = null;
 
     /**
      * @var \GCWorld\Database\Database|DatabaseInterface
@@ -44,54 +42,38 @@ abstract class DirectSingle implements DirectSingleInterface
 
     /**
      * Set this in the event your class needs a non-standard Cache.
-     *
-     * @var string|null
      */
-    protected $_cacheName;
+    protected ?string $_cacheName = null;
 
     /**
-     * @var bool
-     *           Set to false if you want to omit this object from your memory cache all together
+     * Set to false if you want to omit this object from your memory cache all together
      */
-    protected $_canCache = true;
+    protected bool $_canCache = true;
 
     /**
-     * @var int
-     *          TTL for cache items.  -1 = disabled
+     * TTL for cache items.  -1 = disabled
      */
-    protected $_cacheTTL = 60;
+    protected int $_cacheTTL = 60;
 
     /**
-     * @var bool
-     *           Set this to false in your class when you don't want to auto re-cache after a purge
+     * Set this to false in your class when you don't want to auto re-cache after a purge
      */
-    protected $_canCacheAfterPurge = true;
+    protected bool $_canCacheAfterPurge = true;
 
     /**
      * @var Redis|null
      */
-    protected $_cache;
+    protected ?Redis $_cache = null;
 
-    /**
-     * @var array
-     */
-    protected $_changed = [];
+    protected array $_changed = [];
 
-    /**
-     * @var array
-     */
-    protected $_lastChanged = [];
+    protected array $_lastChanged = [];
 
     /**
      * Set this to false in your class when you don't want to log changes.
-     *
-     * @var bool
      */
-    protected $_audit = true;
+    protected bool $_audit = true;
 
-    /**
-     * @var ?string
-     */
     protected ?string $_auditHandler = null;
 
     /**
@@ -99,27 +81,20 @@ abstract class DirectSingle implements DirectSingleInterface
      *
      * @var AuditInterface|null
      */
-    protected $_lastAuditObject;
+    protected ?AuditInterface $_lastAuditObject = null;
 
     /**
      * Setting this to true will enable insert on duplicate key update features.
      * This also includes not throwing an error on 0 id construct.
-     *
-     * @var bool
      */
-    protected $_canInsert = false;
+    protected bool $_canInsert = false;
 
     /**
      * Used for reference and to reduce constant check calls.
-     *
-     * @var string
      */
-    protected $myName;
+    protected readonly string $myName;
 
     /**
-     * @param mixed|null $primary_id
-     * @param array|null $defaults
-     *
      * @throws ORMException
      */
     protected function __construct(mixed $primary_id = null, ?array $defaults = null)
@@ -270,9 +245,6 @@ abstract class DirectSingle implements DirectSingleInterface
         }
     }
 
-    /**
-     * @return bool
-     */
     public function save(): bool
     {
         $table_name   = \constant($this->myName.'::CLASS_TABLE');
@@ -405,8 +377,6 @@ abstract class DirectSingle implements DirectSingleInterface
 
     /**
      * Purges the current item from Redis.
-     *
-     * @return void
      */
     public function purgeCache(): void
     {
@@ -422,54 +392,37 @@ abstract class DirectSingle implements DirectSingleInterface
 
     /**
      * Gets the field keys from the dbInfo array.
-     *
-     * @return array
      */
     public function getFieldKeys(): array
     {
         return \array_keys(static::$dbInfo);
     }
 
-    /**
-     * @return bool
-     */
     public function _hasChanged(): bool
     {
         return \count($this->_changed) > 0;
     }
 
-    /**
-     * @return array
-     */
     public function _getChanged(): array
     {
         return $this->_changed;
     }
 
-    /**
-     * @return array
-     */
     public function _getLastChanged(): array
     {
         return $this->_lastChanged;
     }
 
-    /**
-     * @param string $key
-     *
-     * @return mixed
-     */
-    protected function get(string $key)
+    protected function get(string $key): mixed
     {
         return $this->{$key};
     }
 
     /**
-     * @param array $fields
-     *
-     * @return array
+     * @param string[] $fields
+     * @return array<string, mixed>
      */
-    protected function getArray(array $fields)
+    protected function getArray(array $fields): array
     {
         $return = [];
         foreach ($fields as $k) {
@@ -480,12 +433,9 @@ abstract class DirectSingle implements DirectSingleInterface
     }
 
     /**
-     * @param string $key
-     * @param mixed  $val
-     *
      * @return static
      */
-    protected function set(string $key, $val)
+    protected function set(string $key, mixed $val): static
     {
         if ($this->{$key} !== $val) {
             $this->{$key} = $val;
@@ -498,11 +448,10 @@ abstract class DirectSingle implements DirectSingleInterface
     }
 
     /**
-     * @param array $data
-     *
+     * @param array<string,mixed> $data
      * @return static
      */
-    protected function setArray(array $data)
+    protected function setArray(array $data): static
     {
         foreach ($data as $k => $v) {
             $this->set($k, $v);
@@ -511,10 +460,7 @@ abstract class DirectSingle implements DirectSingleInterface
         return $this;
     }
 
-    /**
-     * @return void
-     */
-    protected function setCacheData()
+    protected function setCacheData(): void
     {
         // Caching Disabled
         if (!$this->_canCache || $this->_cacheTTL < 0) {

--- a/src/CommonLoader.php
+++ b/src/CommonLoader.php
@@ -12,22 +12,20 @@ use GCWorld\Interfaces\CommonInterface;
 class CommonLoader
 {
     /** @var \GCWorld\Common\Common|CommonInterface|null */
-    protected static $common = null;
+    protected static ?CommonInterface $common = null;
 
     /**
      * Sets the common object
-     * @param CommonInterface $common
-     * @return void
      */
-    public static function setCommonObject(CommonInterface $common)
+    public static function setCommonObject(CommonInterface $common): void
     {
         self::$common = $common;
     }
 
     /**
-     * @return \GCWorld\Common\Common|CommonInterface
+     * @return CommonInterface
      */
-    public static function getCommon()
+    public static function getCommon(): CommonInterface
     {
         if (self::$common == null) {
             $cConfig = new Config();

--- a/src/ComposerInstaller.php
+++ b/src/ComposerInstaller.php
@@ -12,11 +12,7 @@ class ComposerInstaller
 {
     const CONFIG_FILE_NAME = 'GCWorld_ORM.yml';
 
-    /**
-     * @param \Composer\Script\Event $event
-     * @return bool
-     */
-    public static function setupConfig(Event $event)
+    public static function setupConfig(Event $event): bool
     {
         $vendorDir = $event->getComposer()->getConfig()->get('vendor-dir');
         $myDir     = dirname(__FILE__);

--- a/src/Config.php
+++ b/src/Config.php
@@ -13,8 +13,8 @@ class Config
 {
     public const VERSION = 5;
 
-    protected string $config_file;
-    protected array  $config = [];
+    protected readonly string $config_file;
+    protected readonly array  $config;
 
     /**
      * Config constructor.
@@ -151,19 +151,12 @@ class Config
         $this->config = $config;
     }
 
-    /**
-     * @return array
-     */
-    public function getConfig()
+    public function getConfig(): array
     {
         return $this->config;
     }
 
-    /**
-     * @param array $config
-     * @return void
-     */
-    protected function upgradeConfig(array &$config)
+    protected function upgradeConfig(array &$config): void
     {
         if ($config['version'] < 4) {
             $config['version'] = 4;
@@ -258,11 +251,7 @@ class Config
         }
     }
 
-    /**
-     * @param array $config
-     * @return void
-     */
-    protected function sortConfig(array &$config)
+    protected function sortConfig(array &$config): void
     {
         unset($config['sort']);
         if (isset($config['tables'])) {
@@ -280,18 +269,12 @@ class Config
         }
     }
 
-    /**
-     * @return string
-     */
     public function getConfigFilePath(): string
     {
         return $this->config_file;
     }
 
-    /**
-     * @return array
-     */
-    public static function getDefaultFieldConfig()
+    public static function getDefaultFieldConfig(): array
     {
         return [
             'visibility'    => 'public',

--- a/src/Core/AuditUtilities.php
+++ b/src/Core/AuditUtilities.php
@@ -12,12 +12,10 @@ use Ramsey\Uuid\Uuid;
 class AuditUtilities
 {
     /**
-     * @param string $table
-     * @param array  $after
-     * @param array  $before
-     * @return CleanAuditData
+     * @param array<string,mixed> $after
+     * @param array<string,mixed> $before
      */
-    public static function cleanData(string $table, array $after, array $before)
+    public static function cleanData(string $table, array $after, array $before): CleanAuditData
     {
         $cConfig = new Config();
         $config  = $cConfig->getConfig()['tables'] ?? [];
@@ -81,11 +79,7 @@ class AuditUtilities
         return $cData;
     }
 
-    /**
-     * @param mixed $str
-     * @return bool
-     */
-    public static function isBinary($str)
+    public static function isBinary(mixed $str): bool
     {
         if (!is_scalar($str)) {
             return true;

--- a/src/Core/CreateAuditTable.php
+++ b/src/Core/CreateAuditTable.php
@@ -10,21 +10,16 @@ class CreateAuditTable
     /**
      * @var DatabaseInterface|\GCWorld\Database\Database
      */
-    protected $_source      = null;
+    protected readonly DatabaseInterface $_source;
     /**
      * @var DatabaseInterface|\GCWorld\Database\Database
      */
-    protected $_destination = null;
-    /**
-     * @var array
-     */
-    protected $config       = [];
+    protected readonly DatabaseInterface $_destination;
+
+    protected readonly array $config;
 
     /**
      * CreateAuditTable constructor.
-     *
-     * @param DatabaseInterface $_source
-     * @param DatabaseInterface $_destination
      */
     public function __construct(DatabaseInterface $_source, DatabaseInterface $_destination)
     {
@@ -33,11 +28,7 @@ class CreateAuditTable
         $this->config       = CommonLoader::getCommon()->getConfig('audit');
     }
 
-    /**
-     * @param string $table
-     * @return void
-     */
-    public function buildTable(string $table)
+    public function buildTable(string $table): void
     {
         /// $schema = $this->_source->getWorkingDatabaseName();
         $preLen = \strlen($this->config['prefix']);

--- a/src/DirectDBClass.php
+++ b/src/DirectDBClass.php
@@ -9,30 +9,24 @@ use GCWorld\ORM\Abstracts\DirectSingle;
  */
 abstract class DirectDBClass extends DirectSingle
 {
-    /**
-     * @param string $key
-     * @return mixed
-     */
-    public function get(string $key)
+    public function get(string $key): mixed
     {
         return parent::get($key);
     }
 
     /**
-     * @param array $fields
-     * @return array
+     * @param string[] $fields
+     * @return array<string,mixed>
      */
-    public function getArray(array $fields)
+    public function getArray(array $fields): array
     {
         return parent::getArray($fields);
     }
 
     /**
-     * @param string $key
-     * @param mixed  $val
-     * @return $this
+     * @return static
      */
-    public function set(string $key, $val)
+    public function set(string $key, mixed $val): static
     {
         parent::set($key, $val);
 
@@ -40,10 +34,10 @@ abstract class DirectDBClass extends DirectSingle
     }
 
     /**
-     * @param array $data
-     * @return $this
+     * @param array<string,mixed> $data
+     * @return static
      */
-    public function setArray(array $data)
+    public function setArray(array $data): static
     {
         parent::setArray($data);
 

--- a/src/Exceptions/ModelImmutableException.php
+++ b/src/Exceptions/ModelImmutableException.php
@@ -9,30 +9,22 @@ use GCWorld\ORM\Interfaces\FieldException;
  */
 class ModelImmutableException extends Exception implements FieldException
 {
-    protected string $field_name = '';
+    protected readonly string $field_name;
 
     /**
-     * ModelRequiredFieldException constructor.
-     *
-     * @param string         $field_name
-     * @param string         $message
-     * @param int            $code
-     * @param Exception|null $previous
+     * ModelImmutableException constructor.
      */
     public function __construct(string $field_name, string $message = '', int $code = 0, ?Exception $previous = null)
     {
-        $this->field_name = $field_name;
+        $this->field_name = $field_name; // Initialize readonly property
 
-        if (empty($message)) {
-            $message = \ucwords(\implode(' ', \explode('_', $field_name))).' is an immutable field and cannot be changed';
+        $finalMessage = $message;
+        if (empty($finalMessage)) {
+            $finalMessage = \ucwords(\implode(' ', \explode('_', $this->field_name))).' is an immutable field and cannot be changed';
         }
-
-        parent::__construct($message, $code, $previous);
+        parent::__construct($finalMessage, $code, $previous);
     }
 
-    /**
-     * @return string
-     */
     public function getFieldName(): string
     {
         return $this->field_name;

--- a/src/Exceptions/ModelInvalidOptionException.php
+++ b/src/Exceptions/ModelInvalidOptionException.php
@@ -9,19 +9,12 @@ use GCWorld\ORM\Interfaces\FieldException;
  */
 class ModelInvalidOptionException extends Exception implements FieldException
 {
-    protected $chosen;
-    protected $possible;
-    protected $field_name;
+    protected readonly mixed $chosen;
+    protected readonly array $possible;
+    protected readonly string $field_name;
 
     /**
      * ModelInvalidOptionException constructor.
-     *
-     * @param string         $field_name
-     * @param mixed          $chosen
-     * @param array          $possible
-     * @param string         $message
-     * @param int            $code
-     * @param Exception|null $previous
      */
     public function __construct(
         string $field_name,
@@ -35,33 +28,24 @@ class ModelInvalidOptionException extends Exception implements FieldException
         $this->chosen     = $chosen;
         $this->possible   = $possible;
 
-        if (empty($message)) {
-            $message = 'Invalid Option ('.$this->chosen.') Selected in Field ('.
-                       \ucwords(\implode(' ', \explode('_', $field_name))).')';
+        $finalMessage = $message;
+        if (empty($finalMessage)) {
+            $finalMessage = 'Invalid Option ('.$this->chosen.') Selected in Field ('.
+                       \ucwords(\implode(' ', \explode('_', $this->field_name))).')';
         }
-
-        parent::__construct($message, $code, $previous);
+        parent::__construct($finalMessage, $code, $previous);
     }
 
-    /**
-     * @return string|null
-     */
-    public function getChosen(): ?string
+    public function getChosen(): mixed
     {
         return $this->chosen;
     }
 
-    /**
-     * @return array|null
-     */
-    public function getPossible(): ?array
+    public function getPossible(): array
     {
         return $this->possible;
     }
 
-    /**
-     * @return string
-     */
     public function getFieldName(): string
     {
         return $this->field_name;

--- a/src/Exceptions/ModelInvalidUUIDFormatException.php
+++ b/src/Exceptions/ModelInvalidUUIDFormatException.php
@@ -9,30 +9,22 @@ use GCWorld\ORM\Interfaces\FieldException;
  */
 class ModelInvalidUUIDFormatException extends Exception implements FieldException
 {
-    protected string $field_name = '';
+    protected readonly string $field_name;
 
     /**
-     * ModelRequiredFieldException constructor.
-     *
-     * @param string         $field_name
-     * @param string         $message
-     * @param int            $code
-     * @param Exception|null $previous
+     * ModelInvalidUUIDFormatException constructor.
      */
     public function __construct(string $field_name, string $message = '', int $code = 0, ?Exception $previous = null)
     {
         $this->field_name = $field_name;
 
-        if (empty($message)) {
-            $message = 'Invalid UUID Format In: '.\ucwords(\implode(' ', \explode('_', $field_name)));
+        $finalMessage = $message;
+        if (empty($finalMessage)) {
+            $finalMessage = 'Invalid UUID Format In: '.\ucwords(\implode(' ', \explode('_', $this->field_name)));
         }
-
-        parent::__construct($message, $code, $previous);
+        parent::__construct($finalMessage, $code, $previous);
     }
 
-    /**
-     * @return string
-     */
     public function getFieldName(): string
     {
         return $this->field_name;

--- a/src/Exceptions/ModelOtherException.php
+++ b/src/Exceptions/ModelOtherException.php
@@ -9,30 +9,22 @@ use GCWorld\ORM\Interfaces\FieldException;
  */
 class ModelOtherException extends Exception implements FieldException
 {
-    protected string $field_name = '';
+    protected readonly string $field_name;
 
     /**
      * ModelOtherException constructor.
-     *
-     * @param string         $field_name
-     * @param string         $message
-     * @param int            $code
-     * @param Exception|null $previous
      */
     public function __construct(string $field_name, string $message = '', int $code = 0, ?Exception $previous = null)
     {
         $this->field_name = $field_name;
 
-        if (empty($message)) {
-            $message = \ucwords(\implode(' ', \explode('_', $field_name))).' is a required field';
+        $finalMessage = $message;
+        if (empty($finalMessage)) {
+            $finalMessage = \ucwords(\implode(' ', \explode('_', $this->field_name))).' is a required field';
         }
-
-        parent::__construct($message, $code, $previous);
+        parent::__construct($finalMessage, $code, $previous);
     }
 
-    /**
-     * @return string
-     */
     public function getFieldName(): string
     {
         return $this->field_name;

--- a/src/Exceptions/ModelRequiredFieldException.php
+++ b/src/Exceptions/ModelRequiredFieldException.php
@@ -9,30 +9,22 @@ use GCWorld\ORM\Interfaces\FieldException;
  */
 class ModelRequiredFieldException extends Exception implements FieldException
 {
-    protected string $field_name = '';
+    protected readonly string $field_name;
 
     /**
      * ModelRequiredFieldException constructor.
-     *
-     * @param string         $field_name
-     * @param string         $message
-     * @param int            $code
-     * @param Exception|null $previous
      */
     public function __construct(string $field_name, string $message = '', int $code = 0, ?Exception $previous = null)
     {
         $this->field_name = $field_name;
 
-        if (empty($message)) {
-            $message = \ucwords(\implode(' ', \explode('_', $field_name))).' is a required field';
+        $finalMessage = $message;
+        if (empty($finalMessage)) {
+            $finalMessage = \ucwords(\implode(' ', \explode('_', $this->field_name))).' is a required field';
         }
-
-        parent::__construct($message, $code, $previous);
+        parent::__construct($finalMessage, $code, $previous);
     }
 
-    /**
-     * @return string
-     */
     public function getFieldName(): string
     {
         return $this->field_name;

--- a/src/Exceptions/ModelSaveExceptions.php
+++ b/src/Exceptions/ModelSaveExceptions.php
@@ -13,14 +13,10 @@ class ModelSaveExceptions extends Exception implements ModelSaveExceptionsInterf
     /**
      * @var Exception[]
      */
-    protected $exceptArray = [];
+    protected array $exceptArray = [];
 
     /**
      * ModelRequiredFieldException constructor.
-     *
-     * @param string         $message
-     * @param int            $code
-     * @param Exception|null $previous
      */
     public function __construct(string $message = '', int $code = 0, ?Exception $previous = null)
     {
@@ -29,10 +25,8 @@ class ModelSaveExceptions extends Exception implements ModelSaveExceptionsInterf
 
     /**
      * @param Exception $e
-     *
-     * @return $this
      */
-    public function addException(Exception $e)
+    public function addException(Exception $e): self
     {
         $this->exceptArray[] = $e;
         $this->message      .= PHP_EOL.$e->getMessage();
@@ -40,9 +34,6 @@ class ModelSaveExceptions extends Exception implements ModelSaveExceptionsInterf
         return $this;
     }
 
-    /**
-     * @return array
-     */
     public function getFieldMessages(): array
     {
         if (!$this->isThrowable()) {
@@ -63,9 +54,6 @@ class ModelSaveExceptions extends Exception implements ModelSaveExceptionsInterf
         return $messages;
     }
 
-    /**
-     * @return bool
-     */
     public function isThrowable(): bool
     {
         return !empty($this->exceptArray);
@@ -73,8 +61,6 @@ class ModelSaveExceptions extends Exception implements ModelSaveExceptionsInterf
 
     /**
      * @throws ModelSaveExceptions
-     *
-     * @return void
      */
     public function doThrow(): void
     {
@@ -86,7 +72,7 @@ class ModelSaveExceptions extends Exception implements ModelSaveExceptionsInterf
     /**
      * @return Exception[]
      */
-    public function getExceptions()
+    public function getExceptions(): array
     {
         return $this->exceptArray;
     }

--- a/src/Exceptions/ModelUniqueValueException.php
+++ b/src/Exceptions/ModelUniqueValueException.php
@@ -9,34 +9,25 @@ use GCWorld\ORM\Interfaces\FieldException;
  */
 class ModelUniqueValueException extends Exception implements FieldException
 {
-    protected string $field_name = '';
-    protected string $value      = '';
+    protected readonly string $field_name;
+    protected readonly string $value;
 
     /**
      * ModelUniqueValueException constructor.
-     *
-     * @param string         $field_name
-     * @param string         $value
-     * @param string         $message
-     * @param int            $code
-     * @param Exception|null $previous
      */
     public function __construct(string $field_name, string $value, string $message = '', int $code = 0, ?Exception $previous = null)
     {
         $this->field_name = $field_name;
         $this->value      = $value;
 
-        if (empty($message)) {
-            $message  = \ucwords(\implode(' ', \explode('_', $field_name))).' is a unique field. ';
-            $message .= 'A value of "'.$value.'" has already been used';
+        $finalMessage = $message;
+        if (empty($finalMessage)) {
+            $finalMessage  = \ucwords(\implode(' ', \explode('_', $this->field_name))).' is a unique field. ';
+            $finalMessage .= 'A value of "'.$this->value.'" has already been used';
         }
-
-        parent::__construct($message, $code, $previous);
+        parent::__construct($finalMessage, $code, $previous);
     }
 
-    /**
-     * @return string
-     */
     public function getFieldName(): string
     {
         return $this->field_name;

--- a/src/FieldName.php
+++ b/src/FieldName.php
@@ -7,29 +7,17 @@ namespace GCWorld\ORM;
  */
 class FieldName
 {
-    /**
-     * @param string $field
-     * @return string
-     */
-    public static function getterName(string $field)
+    public static function getterName(string $field): string
     {
         return 'get'.self::nameConversion($field);
     }
 
-    /**
-     * @param string $field
-     * @return string
-     */
-    public static function setterName(string $field)
+    public static function setterName(string $field): string
     {
         return 'set'.self::nameConversion($field);
     }
 
-    /**
-     * @param string $name
-     * @return mixed
-     */
-    public static function nameConversion(string $name)
+    public static function nameConversion(string $name): string
     {
         return str_replace('_', '', ucwords($name, '_'));
     }

--- a/src/Helpers/CleanAuditData.php
+++ b/src/Helpers/CleanAuditData.php
@@ -10,9 +10,7 @@ class CleanAuditData
     protected array $before = [];
 
     /**
-     * @param array $after
-     *
-     * @return void
+     * @param array<mixed,mixed> $after
      */
     public function setAfter(array $after): void
     {
@@ -20,39 +18,25 @@ class CleanAuditData
     }
 
     /**
-     * @param array $before
-     *
-     * @return void
+     * @param array<mixed,mixed> $before
      */
     public function setBefore(array $before): void
     {
         $this->before = $before;
     }
 
-    /**
-     * @param mixed $key
-     * @param mixed $value
-     *
-     * @return void
-     */
     public function addAfter(mixed $key, mixed $value): void
     {
         $this->after[$key] = $value;
     }
 
-    /**
-     * @param mixed $key
-     * @param mixed $value
-     *
-     * @return void
-     */
     public function addBefore(mixed $key, mixed $value): void
     {
         $this->before[$key] = $value;
     }
 
     /**
-     * @return array
+     * @return array<mixed,mixed>
      */
     public function getAfter(): array
     {
@@ -60,7 +44,7 @@ class CleanAuditData
     }
 
     /**
-     * @return array
+     * @return array<mixed,mixed>
      */
     public function getBefore(): array
     {

--- a/src/ORMException.php
+++ b/src/ORMException.php
@@ -9,33 +9,26 @@ use \Exception;
  */
 class ORMException extends Exception
 {
-    public $backtrace = null;
+    public readonly ?array $backtrace;
 
     /**
      * ORMException constructor.
-     * @param string          $message
-     * @param int             $code
-     * @param \Exception|null $previous
      */
     public function __construct(string $message, int $code = 0, Exception $previous = null)
     {
-        $this->backtrace = debug_backtrace();
         parent::__construct($message, $code, $previous);
+        $this->backtrace = debug_backtrace();
     }
 
     /**
      * custom string representation of object
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return __CLASS__.": [{$this->code}]: {$this->message}\n";
     }
 
-    /**
-     * @return array|null
-     */
-    public function geTrace()
+    public function getTrace(): ?array
     {
         return $this->backtrace;
     }

--- a/src/ORMLogger.php
+++ b/src/ORMLogger.php
@@ -11,21 +11,13 @@ use Monolog\Logger;
  */
 class ORMLogger
 {
-    protected static $logger = null;
+    protected static ?Logger $logger = null;
 
-    /**
-     * @param Logger $logger
-     *
-     * @return void
-     */
-    public static function setLogger(Logger $logger)
+    public static function setLogger(Logger $logger): void
     {
         self::$logger = $logger;
     }
 
-    /**
-     * @return Logger
-     */
     public static function getLogger(): Logger
     {
         if (self::$logger === null) {

--- a/src/Traits/ORMFieldsTrait.php
+++ b/src/Traits/ORMFieldsTrait.php
@@ -7,10 +7,6 @@ namespace GCWorld\ORM\Traits;
  */
 trait ORMFieldsTrait
 {
-    /**
-     * @param string $fieldName
-     * @return string|null
-     */
     public static function getORMFieldTitle(string $fieldName): ?string
     {
         if (!isset(self::$ORM_FIELDS[$fieldName])) {
@@ -20,10 +16,6 @@ trait ORMFieldsTrait
         return self::$ORM_FIELDS[$fieldName]['title'];
     }
 
-    /**
-     * @param string $fieldName
-     * @return string|null
-     */
     public static function getORMFieldDesc(string $fieldName): ?string
     {
         if (!isset(self::$ORM_FIELDS[$fieldName])) {
@@ -33,10 +25,6 @@ trait ORMFieldsTrait
         return self::$ORM_FIELDS[$fieldName]['desc'];
     }
 
-    /**
-     * @param string $fieldName
-     * @return string|null
-     */
     public static function getORMFieldHelp(string $fieldName): ?string
     {
         if (!isset(self::$ORM_FIELDS[$fieldName])) {
@@ -46,10 +34,6 @@ trait ORMFieldsTrait
         return self::$ORM_FIELDS[$fieldName]['help'];
     }
 
-    /**
-     * @param string $fieldName
-     * @return int
-     */
     public static function getORMFieldMaxLength(string $fieldName): int
     {
         if (!isset(self::$ORM_FIELDS[$fieldName])) {

--- a/src/UserLoader.php
+++ b/src/UserLoader.php
@@ -11,25 +11,23 @@ use GCWorld\Interfaces\User;
 class UserLoader
 {
     /**
-     * @var User
+     * @var User|null
      */
-    private static $user = null;
+    private static ?User $user = null;
 
     /**
      * Sets the user object
-     * @param mixed $user
-     * @return void
      */
-    public static function setUserObject($user)
+    public static function setUserObject(User $user): void
     {
         self::$user = $user;
     }
 
     /**
-     * @return mixed
+     * @return User
      * @throws Exception
      */
-    public static function getUser()
+    public static function getUser(): User
     {
         if (self::$user == null) {
             // Attempt loading from a config.ini


### PR DESCRIPTION
This commit introduces extensive type hinting and utilizes PHP 8.x features to enhance the codebase's robustness and compatibility with modern PHP versions.

Key changes include:
- Updated composer.json to require PHP >=8.3 (aiming for 8.4 compatibility).
- Added scalar type hints (string, int, bool, array, etc.), nullable types (?Type), and explicit return types (including void and mixed) to class properties, method parameters, and return values across the src/ directory.
- Applied `readonly` properties to suitable class members to improve immutability.
- Reviewed and refactored core classes such as Config, DirectSingle, ORMException, and Builder.
- Updated PHPDoc blocks to complement native type declarations, removing redundant annotations.

Static Analysis (PHPStan):
- I configured and ran PHPStan at level=max, which revealed 266 errors.
- Critical issues addressed:
    - Corrected ORMException::getTrace() signature for compatibility.
    - Resolved several null safety issues in Abstracts/DirectSingle.php.
- Remaining PHPStan issues:
    - An "Unknown class GCWorld\Interfaces\User" error persists, indicating a potential autoloading or PHPStan configuration problem with this external interface.
    - Numerous errors regarding array type specificity (e.g., `array` lacking specific key/value types like `array<string, mixed>`).
    - Additional null safety warnings and type mismatches.

While not all PHPStan errors were resolved, this work significantly improves the type safety and modernizes the ORM codebase. The unresolved PHPStan errors provide a roadmap for further enhancements.